### PR TITLE
Removing duplicate input

### DIFF
--- a/src/responsive/responsive.ts
+++ b/src/responsive/responsive.ts
@@ -5,7 +5,7 @@ import {responsivePattern, responsiveSubscriptions} from '../config/interfaces';
 
 /*======== RESPONSIVE MULTIPLE =========*/
 @Directive({
-    selector: '[responsive]', inputs: ['responsive']
+    selector: '[responsive]'
 })
 export class Responsive implements OnInit, OnDestroy {
 


### PR DESCRIPTION
Angular2 RC5 freaks out about having duplicate inputs for `responsive`. Removing the one listed in the @Directive decorator fixes this bug.
