### PR TITLE
Upgrading to ng-packagr 2.1.0 for Angular 5 support.

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
     "lib": {
-        "entryFile": "index.ts"
+        "entryFile": "src/index.ts"
     }
 }

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "url": "https://github.com/ManuCutillas/ngx-responsive/issues"
   },
   "homepage": "https://github.com/ManuCutillas/ngx-responsive",
-  "peerDependencies": {
-    "@angular/core": "^5.1.3",
-    "@angular/common": "^5.1.3",
-    "rxjs": "^5.5.6",
-    "zone.js": "^0.8.19"
-  },
   "devDependencies": {
+    "@angular/common": "^5.2.6",
+    "@angular/compiler": "^5.2.6",
+    "@angular/compiler-cli": "^5.2.6",
+    "@angular/core": "^5.2.6",
+    "@angular/platform-browser": "^5.2.6",
+    "@angular/platform-browser-dynamic": "^5.2.6",
     "@types/jasmine": "2.8.0",
     "@types/node": "~8.0.52",
     "codelyzer": "~4.0.1",
@@ -67,11 +67,14 @@
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "ng-packagr": "^1.6.0",
+    "ng-packagr": "^2.1.0",
     "protractor": "~5.2.0",
+    "rxjs": "^5.5.6",
     "ts-node": "~3.3.0",
+    "tsickle": "^0.27.2",
     "tslint": "~5.8.0",
-    "typescript": "~2.6.1"
+    "typescript": "~2.6.1",
+    "zone.js": "^0.8.19"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Had to add peerDependencies to devDependencies or packaging would fail.

Followed these [migration instructions](https://github.com/dherges/ng-packagr/blob/master/CHANGELOG.md#migrating-from-v1-breaking-changes-from-v160-to-v200). Not sure if there are other changes/testing to do.

Addresses #103 