### PR TITLE
feat: enable SSR for responsive directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@
  - responsive-window improvements
    - Add ability to use container reference directly #123
    - add manual refresh action to force refresh when non media event occurs #124
+ - added support for rendering responsive directives on server
 
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "ng serve --aot",
     "build": "ng-packagr -p ng-package.json",
+    "build:watch": "onchange -i -k 'src/**/*.ts' -- npm run build",
     "compodoc": "compodoc -p tsconfig.json",
     "compodoc:serve": "compodoc -s",
     "test": "ng test",
@@ -99,6 +100,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "ng-packagr": "^9.0.0",
+    "onchange": "^7.0.2",
     "protractor": "~5.4.3",
     "source-map-explorer": "^2.2.2",
     "ts-loader": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "$schema": "./node_modules/ng-packagr/package.schema.json",
   "name": "ngx-responsive",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Superset of RESPONSIVE DIRECTIVES to show or hide items according to the size of the device screen and another features in Angular 9",
   "scripts": {
     "start": "ng serve --aot",
     "build": "ng-packagr -p ng-package.json",
+    "build:watch": "onchange -i -k 'src/**/*.ts' -- npm run build",
     "compodoc": "compodoc -p tsconfig.json",
     "compodoc:serve": "compodoc -s",
     "test": "ng test",
@@ -99,6 +100,7 @@
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "ng-packagr": "^9.0.0",
+    "onchange": "^7.0.2",
     "protractor": "~5.4.3",
     "source-map-explorer": "^2.2.2",
     "ts-loader": "^6.2.1",

--- a/src/@core/interfaces/responsive-config.interfaces.ts
+++ b/src/@core/interfaces/responsive-config.interfaces.ts
@@ -13,4 +13,5 @@ export interface IResponsiveConfig {
         xl: { min: number }
     };
     debounceTime: number;
+    renderOnServer?: boolean;
 }

--- a/src/@core/providers/platform-service/platform.service.spec.ts
+++ b/src/@core/providers/platform-service/platform.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { PlatformService } from './platform.service';
+import { PLATFORM_ID } from '@angular/core';
+import { ResponsiveConfig } from '../responsive-config/responsive-config';
+
+describe('PlatformService', () => {
+
+    let service: PlatformService;
+    let platformId: 'browser' | 'server';
+    let responsiveConfig = {
+        config: {
+            breakPoints: {
+                xs: { max: 767 },
+                sm: { min: 768, max: 991 },
+                md: { min: 992, max: 1199 },
+                lg: { min: 1200, max: 1599 },
+                xl: { min: 1600 }
+            },
+            debounceTime: 100,
+            renderOnServer: false
+        }
+    } as ResponsiveConfig
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [PlatformService, 
+                {provide: PLATFORM_ID, useValue: platformId},
+                {provide: ResponsiveConfig, useValue: responsiveConfig}]
+        });
+
+        service = TestBed.inject(PlatformService);
+    });
+
+    describe('isEnabledForPlatform', () => {
+        it('should be enabled if browser but renderOnServer true in config', () => {
+            platformId = 'browser';
+            responsiveConfig = {
+                config: {
+                    ...responsiveConfig.config,
+                    renderOnServer: true
+                }
+            };
+            service = TestBed.inject(PlatformService);
+
+            expect(service.isEnabledForPlatform()).toBe(true);
+        });
+
+        it('should be enabled if NOT browser but renderOnServer true in config', () => {
+            platformId = 'server';
+            responsiveConfig = {
+                config: {
+                    ...responsiveConfig.config,
+                    renderOnServer: true
+                }
+            };
+            service = TestBed.inject(PlatformService);
+
+            expect(service.isEnabledForPlatform()).toBe(true);
+        });
+
+        it('should be enabled if browser and renderOnServer false in config', () => {
+            platformId = 'browser';
+            responsiveConfig = {
+                config: {
+                    ...responsiveConfig.config,
+                    renderOnServer: false
+                }
+            };
+            service = TestBed.inject(PlatformService);
+
+            expect(service.isEnabledForPlatform()).toBe(true);
+        });
+
+        it('should NOT be enabled if NOT browser and renderOnServer false in config', () => {
+            platformId = 'server';
+            responsiveConfig = {
+                config: {
+                    ...responsiveConfig.config,
+                    renderOnServer: false
+                }
+            };
+            service = TestBed.inject(PlatformService);
+
+            expect(service.isEnabledForPlatform()).toBe(false);
+        });
+    });
+    
+});

--- a/src/@core/providers/platform-service/platform.service.ts
+++ b/src/@core/providers/platform-service/platform.service.ts
@@ -1,0 +1,24 @@
+
+
+import { Inject, PLATFORM_ID, Injectable } from '@angular/core';
+import { ResponsiveConfig } from '../responsive-config/responsive-config';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+
+@Injectable()
+export class PlatformService {
+
+  isServer: boolean;
+  isBrowser: boolean;
+
+  constructor(
+    @Inject(PLATFORM_ID) private readonly _platformId,
+    @Inject(ResponsiveConfig) private responsiveConfig: ResponsiveConfig
+  ) {
+    this.isServer = isPlatformServer(_platformId);
+    this.isBrowser = isPlatformBrowser(_platformId);
+  }
+
+  public isEnabledForPlatform() {
+    return this.isBrowser || this.responsiveConfig.config.renderOnServer;
+  }
+}

--- a/src/@core/providers/responsive-base/responsive-base.ts
+++ b/src/@core/providers/responsive-base/responsive-base.ts
@@ -4,12 +4,18 @@
  *
  * @license MIT
  */
-import { EventEmitter, TemplateRef, ViewContainerRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import {
+    EventEmitter,
+    TemplateRef,
+    ViewContainerRef,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 import { IResponsiveSubscriptions } from '../../interfaces';
 import { ResponsiveState } from '../responsive-state/responsive-state';
+import { PlatformService } from '../platform-service/platform.service';
 
 export abstract class RESPONSIVE_BASE<T> implements OnInit, OnDestroy {
 
@@ -39,16 +45,16 @@ export abstract class RESPONSIVE_BASE<T> implements OnInit, OnDestroy {
         ie: false,
         sizes: false
     };
-    private _isBrowser: any = null;
+    private _isEnabledForPlatform: boolean;
 
     constructor(
         private templateRef: TemplateRef<any>,
         private viewContainer: ViewContainerRef,
         private _responsiveState: ResponsiveState,
         private cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected readonly _platformId
+        private platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = this.platformService.isEnabledForPlatform();
     }
 
     protected eventChanges: EventEmitter<any> = new EventEmitter();
@@ -89,14 +95,11 @@ export abstract class RESPONSIVE_BASE<T> implements OnInit, OnDestroy {
     }
 
     public ngOnInit() {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             if (this.set_active_subscriptions.bootstrap) {
                 this._subscription_Bootstrap = this._responsiveState.elemento$.subscribe(this.updateView.bind(this));
             }
 
-            if (this.set_active_subscriptions.bootstrap) {
-                this._subscription_Bootstrap = this._responsiveState.elemento$.subscribe(this.updateView.bind(this));
-            }
 
             if (this.set_active_subscriptions.browser) {
                 this._subscription_Browser = this._responsiveState.browser$.subscribe(this.updateView.bind(this));
@@ -128,7 +131,7 @@ export abstract class RESPONSIVE_BASE<T> implements OnInit, OnDestroy {
     }
 
     public ngOnDestroy() {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             if (this.set_active_subscriptions.bootstrap) {
                 this._subscription_Bootstrap.unsubscribe();
             }
@@ -164,7 +167,7 @@ export abstract class RESPONSIVE_BASE<T> implements OnInit, OnDestroy {
     }
 
     private showHide(show: boolean): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             if (show) {
                 if (this._noRepeat === 0) {
                     this._noRepeat = 1;

--- a/src/@core/providers/responsive-state/responsive-state.ts
+++ b/src/@core/providers/responsive-state/responsive-state.ts
@@ -4,8 +4,7 @@
  *
  * @license MIT
  */
-import { Injectable, PLATFORM_ID, Inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { Injectable } from '@angular/core';
 import { Observable, BehaviorSubject, combineLatest } from 'rxjs';
 import { fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
@@ -25,6 +24,7 @@ import {
     TosSystems, TSmartTv, TGameDevices
 } from '../../types';
 import { ResponsiveConfig } from '../responsive-config/responsive-config';
+import { PlatformService } from '../platform-service/platform.service';
 
 @Injectable()
 export class ResponsiveState {
@@ -42,25 +42,24 @@ export class ResponsiveState {
     public ieVersion$: Observable<any>;
     public userAgent$: Observable<any>;
 
-    private _width: number;
     private _screenWidth: number = null;
     private _screenHeight: number = null;
     private _userAgent: any = null;
-    private _isBrowser: boolean = null;
+    private isEnabledForPlatform: boolean = null;
 
     private _forceRefresh$: BehaviorSubject<null> = new BehaviorSubject<null>(null);
 
     constructor(
+        platformService: PlatformService,
         private _responsiveConfig: ResponsiveConfig,
-        @Inject(PLATFORM_ID) private _platformId
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
-        this._window = (this._isBrowser) ? window : null;
-        this._screenWidth = (this._isBrowser) ? this._window.screen.width : 0;
-        this._screenHeight = (this._isBrowser) ? this._window.screen.height : 0;
-        this._userAgent = (this._isBrowser) ? this._window.navigator.userAgent.toLowerCase() : null;
+        this.isEnabledForPlatform = platformService.isEnabledForPlatform();
+        this._window = (this.isEnabledForPlatform) ? window : null;
+        this._screenWidth = (this.isEnabledForPlatform) ? this._window.screen.width : 0;
+        this._screenHeight = (this.isEnabledForPlatform) ? this._window.screen.height : 0;
+        this._userAgent = (this.isEnabledForPlatform) ? this._window.navigator.userAgent.toLowerCase() : null;
 
-        if(this._isBrowser) {
+        if(this.isEnabledForPlatform) {
            
             const _resize$ =  combineLatest(
                 fromEvent(this._window, 'resize').pipe(
@@ -148,7 +147,7 @@ export class ResponsiveState {
     * @param windowName
     */
     public getWidth(windowName: string = null): any {
-        if (this._windows !== null && this._isBrowser) {
+        if (this._windows !== null && this.isEnabledForPlatform) {
             if (windowName && this._windows[windowName]) {
                 return this._windows[windowName].getWidth();
             } else {
@@ -163,7 +162,7 @@ export class ResponsiveState {
     */
     public getDevicePixelRatio(): any {
         let ratio = 1;
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             if (typeof this._window.screen.systemXDPI !== 'undefined' &&
                 typeof this._window.screen.logicalXDPI !== 'undefined' &&
                 this._window.screen.systemXDPI > this._window.screen.logicalXDPI) {
@@ -179,14 +178,14 @@ export class ResponsiveState {
     * @name getOrientation
     */
     public getOrientation(): any {
-        return (this._isBrowser) ? window.orientation : null;
+        return (this.isEnabledForPlatform) ? window.orientation : null;
     }
 
     /**
     * @name sizeObserver
     */
     public sizeObserver(): any {
-        return (this._windows !== null && this._isBrowser) ? this.getWidth('window') : 0;
+        return (this._windows !== null && this.isEnabledForPlatform) ? this.getWidth('window') : 0;
     }
 
     /**
@@ -195,7 +194,7 @@ export class ResponsiveState {
     public sizeOperations(): any {
         let _sizes = null;
         const _breackpoints = this._responsiveConfig.config.breakPoints;
-        if (this._windows !== null && this._isBrowser && _breackpoints !== null) {
+        if (this._windows !== null && this.isEnabledForPlatform && _breackpoints !== null) {
             const _width = this.getWidth('window');
             if (_breackpoints.xl.min <= _width) {
                 _sizes = 'xl';
@@ -217,7 +216,7 @@ export class ResponsiveState {
      */
     public pixelRatio(): any {
         let _pixelRatio = null;
-        if (this._isBrowser && this._screenWidth !== 0 && this._screenHeight !== 0) {
+        if (this.isEnabledForPlatform && this._screenWidth !== 0 && this._screenHeight !== 0) {
             if (this.testIs4k()) {
                 _pixelRatio = '4k';
             } else if (this.getDevicePixelRatio() > 1) {
@@ -244,7 +243,7 @@ export class ResponsiveState {
      */
     public orientationDevice(): any {
         let _orientationDevice = null;
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             if (this.isMobile() || this.isTablet()) {
                 if (this._window.innerHeight > this._window.innerWidth) {
                     _orientationDevice = 'portrait';
@@ -262,7 +261,7 @@ export class ResponsiveState {
      * @name getUserAgent
      */
     public getUserAgent(): any {
-        return (this._isBrowser) ? this._window.navigator.userAgent.toLowerCase() : null;
+        return (this.isEnabledForPlatform) ? this._window.navigator.userAgent.toLowerCase() : null;
     }
 
     /**
@@ -325,7 +324,7 @@ export class ResponsiveState {
      * @name deviceDetection
      */
     public deviceDetection(): any {
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             if (this.isMobile()) {
                 return 'mobile';
             } else if (this.isTablet()) {
@@ -343,7 +342,7 @@ export class ResponsiveState {
      * @name standardDevices
      */
     public standardDevices(): any {
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             if (REG_MOBILES.IPHONE.REG.test(this._userAgent)) {
                 return 'iphone';
             } else if (REG_TABLETS.IPAD.REG.test(this._userAgent)) {
@@ -363,7 +362,7 @@ export class ResponsiveState {
      * @name ieVersionDetect
      */
     public ieVersionDetect(): any {
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             const _userAgent = this.getUserAgent();
             const msie = _userAgent.indexOf('msie ');
             let _ieVersion = null;
@@ -401,7 +400,7 @@ export class ResponsiveState {
      */
     public browserName(): any {
         let _browserName = null;
-        if (this._isBrowser) {
+        if (this.isEnabledForPlatform) {
             if (REG_SORT_NAMES.WEBKIT.REG.test(this._userAgent) && REG_SORT_NAMES.CHROME.REG.test(this._userAgent)
                 && !REG_BROWSERS.IE.REG.test(this._userAgent)) {
                 _browserName = REG_BROWSERS.CHROME.VALUE;

--- a/src/@directives/bootstrap/bootstrap-directives.ts
+++ b/src/@directives/bootstrap/bootstrap-directives.ts
@@ -8,6 +8,7 @@ import { PLATFORM_ID, Inject } from '@angular/core';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { RESPONSIVE_BASE } from '../../@core/providers/responsive-base/responsive-base';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 @Directive({
     selector: '[xl]'
 })
@@ -15,17 +16,16 @@ export class XlDirective extends RESPONSIVE_BASE<any> {
 
     protected _state = 'xl';
     protected _showWhenTrue = true;
-    @Input() set xl( grid_state: string[] | string ) {
-        this.setGrid(this._state, 'bootstrap');
-    }
+    
     constructor( templateRef: TemplateRef<any>,
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
 
-        super ( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super ( templateRef, viewContainer, _responsiveState, cd, platformService );
+        this.setGrid(this._state, 'bootstrap');
     }
 }
 
@@ -37,16 +37,14 @@ export class LgDirective extends RESPONSIVE_BASE<any> {
 
     protected _state = 'lg';
     protected _showWhenTrue = true;
-    @Input() set lg( grid_state: string[] | string ) {
-        this.setGrid( this._state, 'bootstrap' );
-    }
     constructor( templateRef: TemplateRef<any>,
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
+        this.setGrid( this._state, 'bootstrap' );
     }
 }
 @Directive(
@@ -56,16 +54,15 @@ export class LgDirective extends RESPONSIVE_BASE<any> {
 export class MdDirective extends RESPONSIVE_BASE<any> {
     protected _state = 'md';
     protected _showWhenTrue = true;
-    @Input() set md( grid_state: string[] | string ) {
-        this.setGrid( this._state, 'bootstrap' );
-    }
+    
     constructor( templateRef: TemplateRef<any>,
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
+        this.setGrid( this._state, 'bootstrap' );
     }
 }
 
@@ -76,17 +73,15 @@ export class SmDirective extends RESPONSIVE_BASE<any> {
 
     protected _state = 'sm';
     protected _showWhenTrue = true;
-    @Input() set sm( grid_state: string[] | string ) {
-        this.setGrid( this._state, 'bootstrap' );
-    }
 
     constructor( templateRef: TemplateRef<any>,
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
+        this.setGrid( this._state, 'bootstrap' );
     }
 }
 
@@ -97,16 +92,15 @@ export class XsDirective extends RESPONSIVE_BASE<any> {
 
     protected _state = 'xs';
     protected _showWhenTrue = true;
-    @Input() set xs( grid_state: string[] | string ) {
-        this.setGrid(this._state, 'bootstrap');
-    }
+    
     constructor( templateRef: TemplateRef<any>,
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
+        this.setGrid(this._state, 'bootstrap');
     }
 }
 @Directive(
@@ -122,9 +116,9 @@ export class ShowItBootstrapDirective extends RESPONSIVE_BASE<any> {
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
     }
 }
 @Directive(
@@ -142,8 +136,8 @@ export class HideItBootstrapDirective extends RESPONSIVE_BASE<any> {
                  viewContainer: ViewContainerRef,
                  _responsiveState: ResponsiveState,
                  cd: ChangeDetectorRef,
-                 @Inject(PLATFORM_ID) _platformId 
+                 platformService: PlatformService
     ) {
-        super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+        super( templateRef, viewContainer, _responsiveState, cd, platformService );
     }
 }

--- a/src/@directives/browsers/browser-info.directive.ts
+++ b/src/@directives/browsers/browser-info.directive.ts
@@ -5,12 +5,11 @@
  *
  * @license MIT
  */
-import { EventEmitter, Directive, Input, Output, TemplateRef, ViewContainerRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { EventEmitter, Directive, Input, Output, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { BrowserInfo } from './browser-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive({
     selector: 'browser-info'
@@ -21,10 +20,9 @@ export class BrowserInfoDirective extends BrowserInfo implements OnInit, OnDestr
         this._updateData(this.currentstate);
     }
     constructor(public _responsiveState: ResponsiveState,
-        private viewContainer: ViewContainerRef,
         private cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        protected platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
 
     ngOnInit(): void {
         this.connect();

--- a/src/@directives/browsers/browser-info.rx.ts
+++ b/src/@directives/browsers/browser-info.rx.ts
@@ -5,14 +5,14 @@
  * @license MIT
  */
 import { Injectable} from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { BrowserInfo } from './browser-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Injectable()
 export class BrowserInfoRx extends BrowserInfo  {
     constructor( 
         public _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
 }

--- a/src/@directives/browsers/browser-info.ts
+++ b/src/@directives/browsers/browser-info.ts
@@ -4,28 +4,27 @@
  *
  * @license MIT
  */
-import { PLATFORM_ID, Inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { ReplaySubject } from 'rxjs';
 import { Observable } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 export abstract class BrowserInfo {
     public currentstate: string;
     private _subscription: Subscription;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
     public replaySubject$: ReplaySubject<any> = new ReplaySubject();
     constructor(
         public _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
+        protected platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
     }
     public connect(): Observable<any> {
-        if(this._isBrowser) {
+        if(this._isEnabledForPlatform) {
             this._subscription = this._responsiveState.browser$.pipe(distinctUntilChanged())
             .subscribe((data) => {
                 this._updateData(data);
@@ -34,7 +33,7 @@ export abstract class BrowserInfo {
         return this.replaySubject$.asObservable();
     }
     public disconnect(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
            this._subscription.unsubscribe();
         }
     }

--- a/src/@directives/devices/orientation-info.directive.ts
+++ b/src/@directives/devices/orientation-info.directive.ts
@@ -5,10 +5,10 @@
  * @license MIT
  */
 import { EventEmitter, Directive, Output, ViewContainerRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { OrientationInfo } from './orientation-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive({ selector: 'orientation-info' })
 export class OrientationInfoDirective extends OrientationInfo implements OnInit, OnDestroy {
@@ -16,8 +16,8 @@ export class OrientationInfoDirective extends OrientationInfo implements OnInit,
     constructor(protected _responsiveState: ResponsiveState,
         protected viewContainer: ViewContainerRef,
         protected cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
     ngOnInit() {
         this.connect();
     }

--- a/src/@directives/devices/orientation-info.rx.ts
+++ b/src/@directives/devices/orientation-info.rx.ts
@@ -5,14 +5,14 @@
  * @license MIT
  */
 import { Injectable } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { OrientationInfo } from './orientation-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Injectable()
 export class OrientationInfoRx extends OrientationInfo  {
     constructor( 
         public _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
 }

--- a/src/@directives/devices/orientation-info.ts
+++ b/src/@directives/devices/orientation-info.ts
@@ -12,19 +12,20 @@ import { ReplaySubject } from 'rxjs';
 import { Observable } from 'rxjs';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 export abstract class OrientationInfo {
     public currentstate: string;
     private _subscription: Subscription;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
     public replaySubject$: ReplaySubject<any> = new ReplaySubject();
     constructor(protected _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
+        platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
     }
     public connect(): Observable<any> {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription = this._responsiveState.orientation$.pipe(distinctUntilChanged())
             .subscribe((data) => {
                 this._updateData(data);
@@ -33,7 +34,7 @@ export abstract class OrientationInfo {
         return this.replaySubject$.asObservable();
     }
     public disconnect(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription.unsubscribe();
         }
     }

--- a/src/@directives/pixelratio/pixelratio-directives.ts
+++ b/src/@directives/pixelratio/pixelratio-directives.ts
@@ -11,6 +11,7 @@ import { Subscription } from 'rxjs';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { RESPONSIVE_BASE } from '../../@core/providers/responsive-base/responsive-base';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 /*======== 1x =========*/
 @Directive({
@@ -28,9 +29,9 @@ export class Is1xPixelDirective extends RESPONSIVE_BASE<any> {
                   viewContainer: ViewContainerRef,
                   _responsiveState: ResponsiveState,
                   cd: ChangeDetectorRef,
-                  @Inject(PLATFORM_ID) _platformId 
+                  platformService: PlatformService
          ) {
-         super( templateRef, viewContainer, _responsiveState, cd, _platformId );
+         super( templateRef, viewContainer, _responsiveState, cd, platformService );
     }
 }
 
@@ -89,7 +90,7 @@ export class PixelRatioInfoDirective implements OnInit, OnDestroy {
     public currentstate: string;
     private _subscription: Subscription;
     private noRepeat: string;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
 
     @Input() set pixelratioInfo( grid_state: string[] | string ) {
         this.updateData( this.currentstate );
@@ -101,19 +102,19 @@ export class PixelRatioInfoDirective implements OnInit, OnDestroy {
         private _responsiveState: ResponsiveState,
         private viewContainer: ViewContainerRef,
         private cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
+        platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
     }
 
     ngOnInit() {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription = this._responsiveState.pixel$.subscribe(this.updateData.bind( this ));
         }
     }
 
     ngOnDestroy() {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription.unsubscribe();
         }
     }

--- a/src/@directives/responsive-size-info/responsive-size-info.directive.ts
+++ b/src/@directives/responsive-size-info/responsive-size-info.directive.ts
@@ -5,10 +5,10 @@
  * @license MIT
  */
 import { Directive, EventEmitter, Input, Output, ViewContainerRef, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { ResponsiveSizeInfo } from './responsive-size-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive({ selector: 'responsiveSizeInfo' })
 export class ResponsiveSizeInfoDirective extends ResponsiveSizeInfo implements OnInit, OnDestroy {
@@ -21,8 +21,8 @@ export class ResponsiveSizeInfoDirective extends ResponsiveSizeInfo implements O
     constructor(public _responsiveState: ResponsiveState,
         public viewContainer: ViewContainerRef,
         public cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
     ngOnInit(): void {
         this.connect();
     }

--- a/src/@directives/responsive-size-info/responsive-size-info.rx.ts
+++ b/src/@directives/responsive-size-info/responsive-size-info.rx.ts
@@ -5,14 +5,14 @@
  * @license MIT
  */
 import { Injectable } from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { ResponsiveSizeInfo } from './responsive-size-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Injectable()
 export class ResponsiveSizeInfoRx extends ResponsiveSizeInfo {
     constructor( 
         public _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
 }

--- a/src/@directives/responsive-size-info/responsive-size-info.ts
+++ b/src/@directives/responsive-size-info/responsive-size-info.ts
@@ -4,26 +4,25 @@
  *
  * @license MIT
  */
-import { PLATFORM_ID, Inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
 import { ReplaySubject } from 'rxjs';
 import { Observable } from 'rxjs';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 export abstract class ResponsiveSizeInfo {
     private _subscription: Subscription;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
     public replaySubject$: ReplaySubject<any> = new ReplaySubject<any>();
     constructor( public _responsiveState: ResponsiveState,
-        @Inject(PLATFORM_ID) protected _platformId
+        platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
     }
     public connect(): Observable<any> {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription = this._responsiveState.elemento$.pipe(distinctUntilChanged())
                 .subscribe((data) => {
                     this._updateData(data);
@@ -32,7 +31,7 @@ export abstract class ResponsiveSizeInfo {
         return this.replaySubject$.asObservable();
     }
     public disconnect(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._subscription.unsubscribe();
         }
     }

--- a/src/@directives/responsive-window/responsive-window.ts
+++ b/src/@directives/responsive-window/responsive-window.ts
@@ -11,6 +11,7 @@ import { ResponsiveState } from '../../@core/providers/responsive-state/responsi
 import { ResponsiveConfig } from "../../@core/providers/responsive-config/responsive-config";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive({
     selector: "[responsive-window]",
@@ -20,7 +21,7 @@ export class ResponsiveWindowDirective implements OnInit, OnDestroy, DoCheck {
 
     private _noRepeat: string;
     private element: HTMLElement;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
 
     @Input('responsive-window') name: string;
 
@@ -30,11 +31,11 @@ export class ResponsiveWindowDirective implements OnInit, OnDestroy, DoCheck {
         private _responsiveState: ResponsiveState,
         private el: ElementRef,
         private cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId,
+        platformService: PlatformService,
         private _responsiveConfig: ResponsiveConfig) {
 
-        this._isBrowser = isPlatformBrowser(this._platformId);
-        if (this._isBrowser) {
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
+        if (this._isEnabledForPlatform) {
             this.element = el.nativeElement;
         }
 
@@ -45,13 +46,13 @@ export class ResponsiveWindowDirective implements OnInit, OnDestroy, DoCheck {
             );
     }
     public ngOnInit(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._responsiveState.registerWindow(this);
         }
     }
 
     public ngDoCheck(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             const _update = this._ifValueChanged(this._noRepeat, this.name);
             if (_update) {
                 this._responsiveState.unregisterWindow(this);
@@ -61,13 +62,13 @@ export class ResponsiveWindowDirective implements OnInit, OnDestroy, DoCheck {
         }
     }
     public ngOnDestroy() {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             this._responsiveState.unregisterWindow(this);
         }
     }
 
     public getWidth() {
-        return (this._isBrowser) ? this.element.offsetWidth : 0;
+        return (this._isEnabledForPlatform) ? this.element.offsetWidth : 0;
     }
 
     public getCurrentBreakpoint(): string {

--- a/src/@directives/responsive/responsive.ts
+++ b/src/@directives/responsive/responsive.ts
@@ -12,6 +12,7 @@ import { Subscription } from 'rxjs';
 import { IResponsivePattern, IResponsiveSubscriptions } from '../../@core';
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { ResponsiveWindowDirective } from "../responsive-window/responsive-window";
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive(
     {
@@ -47,7 +48,7 @@ export class ResponsiveDirective implements OnDestroy {
     @Output() changes: EventEmitter<any> = new EventEmitter();
     private _windows = null;
     private _window = null;
-    private _isBrowser: boolean = null;
+    private _isEnabledForPlatform: boolean = null;
     public set_values: IResponsivePattern = {
         bootstrap: '',
         browser: '',
@@ -123,9 +124,9 @@ export class ResponsiveDirective implements OnDestroy {
         private _responsiveState: ResponsiveState,
         private viewContainer: ViewContainerRef,
         private cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
+        platformService: PlatformService
     ) {
-        this._isBrowser = isPlatformBrowser(this._platformId);
+        this._isEnabledForPlatform = platformService.isEnabledForPlatform();
     }
 
     public init_responsive(): void {
@@ -193,7 +194,7 @@ export class ResponsiveDirective implements OnDestroy {
                 this._actives.push(key);
             }
         }
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             if (this.set_active_subscriptions.bootstrap) {
                 this._subscription_Bootstrap = this._responsiveState.elemento$.subscribe(this.updateBootstrap.bind(this));
             }
@@ -260,7 +261,7 @@ export class ResponsiveDirective implements OnDestroy {
     }
     private updateSizes(value: number): void {
         if(this.responsiveContainer){
-            this.set_values.sizes = this._isBrowser ? this.responsiveContainer.getWidth() : 0;
+            this.set_values.sizes = this._isEnabledForPlatform ? this.responsiveContainer.getWidth() : 0;
         }else if (this._sizes_window){
             this.set_values.sizes = this._responsiveState.getWidth(this._sizes_window);
         }else{
@@ -371,7 +372,7 @@ export class ResponsiveDirective implements OnDestroy {
     }
 
     public ngOnDestroy(): void {
-        if (this._isBrowser) {
+        if (this._isEnabledForPlatform) {
             if (this.set_active_subscriptions.bootstrap) {
                 this._subscription_Bootstrap.unsubscribe();
             }

--- a/src/@directives/useragent/useragent-info.directive.ts
+++ b/src/@directives/useragent/useragent-info.directive.ts
@@ -5,11 +5,10 @@
  * @license MIT
  */
 import { Output, EventEmitter, Directive, OnInit, OnDestroy, ChangeDetectorRef} from '@angular/core';
-import { PLATFORM_ID, Inject } from '@angular/core';
-import { Subscription } from 'rxjs';
 
 import { ResponsiveState } from '../../@core/providers/responsive-state/responsive-state';
 import { UserAgentInfo } from './useragent-info';
+import { PlatformService } from '../../@core/providers/platform-service/platform.service';
 
 @Directive(
 {
@@ -20,8 +19,8 @@ export class UserAgentInfoDirective extends UserAgentInfo implements OnInit, OnD
     constructor(
         public _responsiveState: ResponsiveState,
         public cd: ChangeDetectorRef,
-        @Inject(PLATFORM_ID) protected _platformId
-    ) { super(_responsiveState, _platformId); }
+        platformService: PlatformService
+    ) { super(_responsiveState, platformService); }
     public ngOnInit(): void {
         this.connect();
     }

--- a/src/responsive.module.ts
+++ b/src/responsive.module.ts
@@ -20,7 +20,7 @@ import { RESPONSIVE_SIZE_INFO_DIRECTIVE, RESPONSIVE_SIZE_INFO_RX } from './@dire
 import { RESPONSIVEWINDOW_DIRECTIVE } from './@directives/responsive-window/index';
 import { USERAGENT_INFO_DIRECTIVE, USERAGENT_INFO_RX } from './@directives/useragent/index';
 import { IResponsiveConfig } from './@core/interfaces/responsive-config.interfaces';
-import { DEFAULT_BREACKPOINTS } from './@core/constants/default-breackpoints.constants';
+import { PlatformService } from './@core/providers/platform-service/platform.service';
 export const RESPONSIVE_CONFIGURATION = new InjectionToken<IResponsiveConfig>('config');
 
 export function responsiveConfiguration(config: IResponsiveConfig) {
@@ -66,14 +66,16 @@ export class ResponsiveModule {
                         lg: { min: 1200, max: 1599 },
                         xl: { min: 1600 }
                     },
-                    debounceTime: 100
-                } 
+                    debounceTime: 100,
+                    renderOnServer: false
+                } as IResponsiveConfig
             },{
                 provide: ResponsiveConfig,
                 useFactory: responsiveConfiguration,
                 deps:[RESPONSIVE_CONFIGURATION]
             },
             ResponsiveState,
+            PlatformService,
             RESPONSIVE_SIZE_INFO_RX,
             USERAGENT_INFO_RX,
             BROWSER_INFO_RX,


### PR DESCRIPTION
Closes #142 

- Support rendering responsive directives on the server
- This is enabled by setting the `renderOnServer` config option, so it should be 100% backward compatible

This is enabling the library to render on server with SSR if we set the innerWidth on the server like:

`function setWindowWidth(width: number) {
  global['window'].screen = { width: width };
  global['window'].innerWidth = width;
}`

Tested it, at it works like a charm with SSR.