### PR TITLE
#92 Update regex to detect microsoft edge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ expamples/package-lock.json
 # IDEs
 /.idea
 /.vscode
+*.iml
 
 # misc
 *.js

--- a/src/@core/constants/reg-expressions.constants.ts
+++ b/src/@core/constants/reg-expressions.constants.ts
@@ -171,7 +171,7 @@ export const REG_IE_VERSIONS = {
         VALUE: null
     },
     MS_EDGE: {
-        REG: /edge/i,
+        REG: /edg/i,
         VALUE: null
     }
 };
@@ -198,7 +198,7 @@ export const REG_BROWSERS = {
         VALUE: BROWSER_NAMES.OPERA
     },
     IE: {
-        REG: /msie|trident|edge/,
+        REG: /msie|trident|edg/,
         VALUE: BROWSER_NAMES.IE
     },
     SILK: {

--- a/src/@core/providers/responsive-state/responsive-state.ts
+++ b/src/@core/providers/responsive-state/responsive-state.ts
@@ -387,7 +387,7 @@ export class ResponsiveState {
                 }
             }
 
-            // let edge = this._userAgent.indexOf('Edge/')
+            // let edge = this._userAgent.indexOf('Edg/')
             if (REG_IE_VERSIONS.MS_EDGE.REG.test(_userAgent)) {
                 return IE_VERSIONS.IE_12;
             }


### PR DESCRIPTION
Addresses #92 

Base on latest data about edge browsers, microsoft has mostly abandoned
`Edge/` in favor of `Edg/`. For examples, see

https://www.whatismybrowser.com/guides/the-latest-user-agent/edge

Apparently on Xbox still uses the legacy user-agent. As a result, I've
changed the regex to `/edg/` instead of `/edge/`, and you should now
be able to detect edge browsers on all devices again.