### PR TITLE
Fixed generic issue in ResponsiveModule

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,4 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "version": 1
+  "version": 1,
+  "cli": {
+    "analytics": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "angular7",
     "angular8",
     "angular9",
+    "angular10",
     "ng2",
     "ng",
     "ngx",

--- a/src/responsive.module.ts
+++ b/src/responsive.module.ts
@@ -53,7 +53,7 @@ export function responsiveConfiguration(config: IResponsiveConfig) {
         ]
 })
 export class ResponsiveModule {
-    public static forRoot(config: IResponsiveConfig = null): ModuleWithProviders {
+    public static forRoot(config: IResponsiveConfig = null): ModuleWithProviders<ResponsiveModule> {
         return {
             ngModule: ResponsiveModule,
             providers: [            {


### PR DESCRIPTION
This was the only thing needed to make Angular 10 happy. I did experience an exception when trying to run 

`ng update @angular/core @angular/cli`

 but couldn't find where in the code it was blowing up.

```
➜  ngx-responsive git:(angular-10-support) ng update --force @angular/core @angular/cli
Your global Angular CLI version (10.0.1) is greater than your local
version (9.1.10). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
The installed local Angular CLI version is older than the latest stable version.
Installing a temporary version to perform the update.
Installing packages for tooling via yarn.
Installed packages for tooling via yarn.
Using package manager: 'yarn'
Collecting installed dependencies...
Found 28 dependencies.
Fetching dependency metadata from registry...
                  Package "@angular/core" has a missing peer dependency of "rxjs" @ "^6.5.3".
                  Package "@nguniversal/module-map-ngfactory-loader" has an incompatible peer dependency to "@angular/core" (requires "^8.2.0" (extended), would install "10.0.2").
                  Package "@angular/common" has a missing peer dependency of "rxjs" @ "^6.5.3".
                  Package "@nguniversal/module-map-ngfactory-loader" has an incompatible peer dependency to "@angular/common" (requires "^8.2.0" (extended), would install "10.0.2").
                  Package "@nguniversal/module-map-ngfactory-loader" has an incompatible peer dependency to "@angular/platform-server" (requires "^8.2.0" (extended), would install "10.0.2").
                  Package "ng-packagr" has an incompatible peer dependency to "typescript" (requires ">=3.6 < 3.9", would install "3.9.6").
    Updating package.json with dependency @angular/core @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/cli @ "10.0.1" (was "9.1.10")...
    Updating package.json with dependency @angular/common @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/compiler @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/compiler-cli @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/animations @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/platform-browser-dynamic @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/language-service @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/platform-server @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency @angular/platform-browser @ "10.0.2" (was "9.1.11")...
    Updating package.json with dependency typescript @ "3.9.6" (was "3.8.3")...
UPDATE package.json (2975 bytes)
✔ Packages installed successfully.
** Executing migrations of package '@angular/core' **

❯ Missing @Injectable and incomplete provider definition migration.
  As of Angular 9, enforcement of @Injectable decorators for DI is a bit stricter and incomplete provider definitions behave differently.
  Read more about this here: https://v9.angular.io/guide/migration-injectable
✖ Migration failed: Cannot convert undefined or null to object
  See "/private/var/folders/h4/cgdfqbfx61s5r8kc3lpx119h0000gn/T/ng-qRjw77/angular-errors.log" for further details.
```